### PR TITLE
Revert "protect main branch"

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,13 +2,6 @@ data "github_repositories" "mine" {
   query = "org:oke-py archived:false"
 }
 
-resource "github_branch_protection_v3" "main" {
-  for_each = toset(data.github_repositories.mine.names)
-
-  repository = each.key
-  branch     = "main"
-}
-
 resource "github_repository_file" "editorconfig" {
   for_each = toset(data.github_repositories.mine.names)
 


### PR DESCRIPTION
This reverts commit 3343de70198fca9cdb28ba463777c0b1338d13d4.

`terraform apply` failed.

> Error: this resource can only be used in the context of an organization, "oke-py" is a user
with github_branch_protection_v3.main["ansible-osx"]
on main.tf line 5, in resource "github_branch_protection_v3" "main":